### PR TITLE
Some fixes for the about page

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -6,12 +6,17 @@ title = 'About'
 
 ## About this blog
 
-This is the official blog for the [k0s project](https//k0sproject.io).
+This is the official blog for the [k0s project].
 
 Here we will share news, technical deep-dives, and practical guides around:
 
-- [k0s](https://k0sproject.io/) - the simple, solid and certified [Kubernetes](https://kubernetes.io/) distribution
-- [k0smotron](https://k0smotron.io/) - the Kubernetes control plane manager
+- [k0s] - the simple, solid and certified [Kubernetes] distribution
+- [k0smotron] - the Kubernetes control plane manager
 
-Our goal is to make Kubernetes more approachable while showing what makes k0s and k0smotron unique.
-Thanks for stopping by!
+Our goal is to make Kubernetes more approachable while showing what makes k0s
+and k0smotron unique. Thanks for stopping by!
+
+[k0s project]: https://k0sproject.io/
+[k0s]: https://k0sproject.io/
+[Kubernetes]: https://kubernetes.io/
+[k0smotron]: https://k0smotron.io/

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -6,7 +6,7 @@ title = 'About'
 
 ## About this blog
 
-This is the official blog for the [k0s project].
+This is the official blog for the [k0sproject].
 
 Here we will share news, technical deep-dives, and practical guides around:
 
@@ -16,7 +16,7 @@ Here we will share news, technical deep-dives, and practical guides around:
 Our goal is to make Kubernetes more approachable while showing what makes k0s
 and k0smotron unique. Thanks for stopping by!
 
-[k0s project]: https://k0sproject.io/
+[k0sproject]: https://github.com/k0sproject/
 [k0s]: https://k0sproject.io/
 [Kubernetes]: https://kubernetes.io/
 [k0smotron]: https://k0smotron.io/

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -8,12 +8,10 @@ title = 'About'
 
 This is the official blog for the [k0s project](https//k0sproject.io).
 
-Here we will share new, technical deep-dives, and practical guides around:
+Here we will share news, technical deep-dives, and practical guides around:
 
 - [k0s](https://k0sproject.io/) - the simple, solid and certified [Kubernetes](https://kubernetes.io/) distribution
 - [k0smotron](https://k0smotron.io/) - the Kubernetes control plane manager
 
-Our goal is to make Kubernetes more approachable while showing what makes k0s and k0smostron unique.
+Our goal is to make Kubernetes more approachable while showing what makes k0s and k0smotron unique.
 Thanks for stopping by!
-
-


### PR DESCRIPTION
* Fix typos
  * new -> news
  * k0smostron -> k0smotron
* Use Markdown links at the bottom of the page. Makes the running text more readable. 
* Add a missing colon to the k0sproject link.
* Use hard line wraps.
* Let the link to k0sproject to point to the GitHub org. The k0sproject.io mini site is mostly about k0s. Using the GitHub org will better indicate that it's not only k0s which is part of the project IMO. Don't use a space between k0s and project for similar reasons.